### PR TITLE
Create dict for configuring prosodic

### DIFF
--- a/poesy/poesy.py
+++ b/poesy/poesy.py
@@ -15,6 +15,9 @@ METER='default_english'
 
 MAX_RHYME_DIST=5
 
+# External Config
+PROSODIC_CONFIG = {}
+
 def test():
 	# poemtxt="""FROM fairest creatures we desire increase,
 	# That thereby beauty's rose might never die,
@@ -718,6 +721,7 @@ class Poem(object):
 		if not hasattr(self,'_prosodic'):
 			import prosodic as p
 			p.config['print_to_screen']=0
+			p.config.update(PROSODIC_CONFIG)
 			self._prosodic=pd={}
 			numlines=len(self.lined)
 			for _i,(i,line) in enumerate(sorted(self.lined.items())):


### PR DESCRIPTION
Allows setting a config that poesy transparently passes to prosodic, which avoids having to import both poesy *and* prosodic in order to change prosodic config. For instance:
```py
import poesy
poesy.PROSODIC_CONFIG["en_TTS_ENGINE"] = "espeak"
```
Unfortunately `poesy.PROSODIC_CONFIG = ...` would have no effect, because it sets the name in the `__init__.py` module rather than `poesy` itself. You have to change the dictionary itself rather than overwriting it, using either item assignment like in the example, or the `update` method.